### PR TITLE
chore(privacy): rotate PII hash salt

### DIFF
--- a/tools/config/privacy-policy.json
+++ b/tools/config/privacy-policy.json
@@ -1,9 +1,10 @@
 {
-  "hash_salt": "3d58e99275ead492d4daabdf2d92c124",
+  "hash_salt": "8588258e2114b3177631d1ad42c05605",
   "previous_salts": [
+    "3d58e99275ead492d4daabdf2d92c124",
     "dev-salt-placeholder"
   ],
   "multi_category_block_threshold": 2,
   "sample_truncate_chars": 6,
-  "last_rotated_utc": "2025-08-15T09:54:54.463Z"
+  "last_rotated_utc": "2025-08-15T11:20:24.223Z"
 }


### PR DESCRIPTION
Automated daily rotation of PII hash salt.

- Updates `tools/config/privacy-policy.json`
- Keeps last 7 salts in history
- See rotation artifact in the workflow run